### PR TITLE
Use secrets for username and password in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Put this lines into the configuration:
 ```yaml
 lock:
   - platform: tedee
-    username: tedee-username
-    password: tedee-password
+    username: !secret tedee_username
+    password: !secret tedee_password
 ```
 
 After restart of Homeassistant you should see the lock:


### PR DESCRIPTION
Hey!

Thanks for your work on this custom component!

This is a small PR that changes readme - instead of hardcoding username and password in config we suggest to use secrets.yml instead ;)